### PR TITLE
remove volumes to restart app after gem and packeges updates

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,12 @@ set -v
 echo "removing all containers..."
 docker ps -aq | xargs docker stop | xargs docker rm
 
+echo "removing old web image..."
+docker rmi asta-web
+
+echo "removing caches packages and gems"
+docker volume rm asta_gem_cache
+docker volume rm asta_node_modules
+
 bundle install
 docker-compose up


### PR DESCRIPTION
@edcolen Acho que com isso resolve o problema dos containeres não subirem depois de um merge da main.
Não sei se é a melhor solução ainda. Mas a gente vai ajustando aos poucos se precisar. :)