### PR TITLE
renames addressable to asta_addressable

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,5 @@
 class Address < ApplicationRecord
-  belongs_to :addressable, polymorphic: true
+  belongs_to :asta_addressable, polymorphic: true
 
   validates :street, :number, :neighborhood, :city, :state, presence: true
   validates :state, length: { is: 2 }

--- a/app/models/concerns/asta_addressable.rb
+++ b/app/models/concerns/asta_addressable.rb
@@ -1,4 +1,4 @@
-module Addressable
+module AstaAddressable
   extend ActiveSupport::Concern
 
   def self.included(base = nil, &)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,11 @@
 class User < ApplicationRecord
+  include AstaAddressable
   include Phonable
-  include Addressable
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
-  # has_many :addresses, as: :addressable
 
   validates :full_name, :username, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
@@ -17,7 +15,7 @@ class User < ApplicationRecord
 
   has_many :user_roles
   has_many :roles, through: :user_roles
-  
+
   private
 
   def check_full_name

--- a/db/migrate/20230322181606_rename_addressable_to_asta_addressable.rb
+++ b/db/migrate/20230322181606_rename_addressable_to_asta_addressable.rb
@@ -1,0 +1,6 @@
+class RenameAddressableToAstaAddressable < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :addresses, :addressable_type, :asta_addressable_type
+    rename_column :addresses, :addressable_id, :asta_addressable_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_16_180651) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_22_181606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,8 +43,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_16_180651) do
   end
 
   create_table "addresses", force: :cascade do |t|
-    t.string "addressable_type", null: false
-    t.bigint "addressable_id", null: false
+    t.string "asta_addressable_type", null: false
+    t.bigint "asta_addressable_id", null: false
     t.string "street"
     t.string "number"
     t.string "complement"
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_16_180651) do
     t.float "latitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
+    t.index ["asta_addressable_type", "asta_addressable_id"], name: "index_addresses_on_addressable"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,7 +80,7 @@ Address.create!(
   neighborhood: 'Portal do Sol 1',
   city: 'Goiânia',
   state: 'GO',
-  addressable: designer
+  asta_addressable: designer
 )
 
 puts 'creating address...'
@@ -90,7 +90,7 @@ Address.create!(
   neighborhood: 'Ahú',
   city: 'Curitiba',
   state: 'PR',
-  addressable: producer
+  asta_addressable: producer
 )
 
 puts 'Fim'


### PR DESCRIPTION
Fixes the following issue when loading web server:
```
| Exiting
asta-web-1 | /app/app/models/user.rb:13:in `<class:User>': uninitialized constant Addressable::URI::MailTo (NameError)
asta-web-1 |
asta-web-1 |  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
```

Turns out ruby already has a library with a class 'addressable'. Since we weren't importing it. It was failing when looking for it. So I renamed our module to AstaAddressable so the app doesn't get confused.
